### PR TITLE
#15391 - Add section on service-version header to interface-doc

### DIFF
--- a/doc/general/operation-modes/operation-modes.md
+++ b/doc/general/operation-modes/operation-modes.md
@@ -34,6 +34,38 @@ The queue nutshell serves to encapsulate the functionality of a receipt chain fo
 
 The Helper nutshell is used to support updates and configurations.
 
+#### fiskaltrust.SignatureCloud
+
+The fiskaltrust.SignatureCloud is a pure online solution. The receipt linking is handled entirely online. The advantage of this solution is that no installation or configuration is required for the client and any platform can use this service.
+
+The fiskaltrust.SignatureCloud has two different versions:
+ - 1.1
+ - 1.2
+
+We differentiate between them by backend servers. So the external url is the same: https://signaturcloud.fiskaltrust.at for both versions. If you want to use a specific version of fiskaltrust.SignatureCloud, you will need to set the service-version parameter into the header. As default the fiskaltrust.SignatureCloud 1.1 version is used.
+
+```
+Example:
+curl -X GET https://signaturcloud.fiskaltrust.at/api/version -H 'service-version: 1.2'
+
+[
+  "fiskaltrust.space.signaturcloud",
+  "1.49.19218.17628-dev+f5672f3d7a",
+  "1.49.19218.17628",
+  "Service package:fiskaltrust.service.azure.net46.dll",
+  "Service product version:1.2",
+  "Service file version:1.2.19089.12258"
+]
+
+curl -X GET https://signaturcloud.fiskaltrust.at/api/version or
+curl -X GET https://signaturcloud.fiskaltrust.at/api/version -H 'service-version: 1.1'
+[
+  "fiskaltrust.space.signaturcloud",
+  "1.1",
+  "1.1.17249.2687"
+]
+```
+
 ### Configuration of the fiskaltrust.Service
 
 #### Online Portal


### PR DESCRIPTION
Extended the general operation-modes markdown file with the new section where you can found out how to access a specific signaturcloud version.